### PR TITLE
Update to support Spring 5.x and above.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,25 +47,25 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
-            <version>3.0.2.RELEASE</version>
+            <version>5.1.2.RELEASE</version>
         </dependency>
         <!--test-->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.3.154</version>
+            <version>1.4.197</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.1</version>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -77,8 +77,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Motivation
----------
The current library supports a baseline of Spring 3.x which is quite old and no longer supported. It also has a JDK baseline of JDK 1.4 which is far out of date. Since Spring 5.x the JdbcTemplate implementation has removed the NativeJdbcExtractor interface as it is no longer needed with JDBC 4.0 drivers and the unwrap(Class<?>) method. Because of this breaking change, this library no longer functions with Spring 5.x and above.

Modifications
-------------
The dependencies defined in the POM file have been brought up to their latest stable versions. This includes moving Spring to 5.1.x and the test dependencies to the newest versions. The JDK target version has also been updated to JDK 8 as it is the oldest supported version supported by Spring. Finally, the code has been updated to remove usages of the NativeJdbcExtractor as it is no longer needed.

Result
------
The library will now function on modern versions of Spring as well as remaining backward compatible with older versions (albeit without NativeJdbcExtractor support).